### PR TITLE
:bug: fix: pong 게임 창에 반복하여 접근할수록 애니메이션 프레임이 올라가는 현상 수정

### DIFF
--- a/frontend/src/components/Local.js
+++ b/frontend/src/components/Local.js
@@ -1,6 +1,8 @@
 import AbstractComponent from "./AbstractComponent.js";
 import init from "../games/local_pong.js"
 
+import animateGame from "../utils/animateGameModule.js";
+
 export default class extends AbstractComponent {
 	constructor() {
 		super();
@@ -17,6 +19,7 @@ export default class extends AbstractComponent {
 	}
 
 	handleRoute() {
+		animateGame.setAnimateOff();
 		const goBackButton = document.querySelector("#goBackButton");
 		goBackButton.addEventListener("click", event => {
 			window.history.back();

--- a/frontend/src/games/local_pong.js
+++ b/frontend/src/games/local_pong.js
@@ -1,3 +1,5 @@
+import animateGame from "../utils/animateGameModule.js";
+
 let
 local = true,
 online = false,
@@ -89,10 +91,23 @@ score = {
 
 function init()
 {
+  setGameStatus();
   setScoreBoard()
   setGame();
   setEvent();
+  animateGame.setAnimateOn();
   loop();
+}
+
+function setGameStatus()
+{
+  game = false;
+  end = false;
+  difficulty = 0;
+  score = {
+    player1: 0,
+    player2: 0
+  };
 }
 
 function setScoreBoard()
@@ -209,6 +224,7 @@ function containerEventKeyDown(e)
       paddle1.position.x = 0;
       paddle2.position.x = 0;
       end = false;
+      loop();
     }
   }
   else if (difficulty === 0)
@@ -303,10 +319,17 @@ function containerEventKeyUp(e)
 
 function loop()
 {
-  requestAnimationFrame(loop);
+  let num = requestAnimationFrame(loop);
   if (game === true && end === false)
     simulation_ball();
   simulation_paddle();
+  if (animateGame.getAnimate() === false)
+    end = true;
+  if (end === true)
+  {
+    stopBall();
+    cancelAnimationFrame(num);
+  }
   renderer.render(scene, camera);
 }
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -14,6 +14,7 @@ import Room from "./components/Room.js";
 import NotFound from "./components/NotFound.js";
 
 import LoginModule from "./utils/loginmodule.js";
+import animateGame from "./utils/animateGameModule.js";
 
 const ROUTE_PARAMETER_REGEX = /:(\w+)/g;
 const URL_FRAGMENT_REGEX = /\//g;
@@ -33,6 +34,8 @@ const routes = [
 ];
 
 const router = async () => {
+	animateGame.setAnimateOff();
+
 	const potentialMatches = routes.map(route => {
 		return {
 			route: route,

--- a/frontend/src/utils/animateGameModule.js
+++ b/frontend/src/utils/animateGameModule.js
@@ -1,0 +1,21 @@
+class AnimateGame {
+	constructor() {
+		this.animate = false;
+	}
+
+	setAnimateOn() {
+		this.animate = true;
+	}
+
+	setAnimateOff() {
+		this.animate = false;
+	}
+
+	getAnimate() {
+		return (this.animate);
+	}
+}
+
+var animateGame = new AnimateGame();
+
+export default animateGame;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - local pong game 페이지에 접근할 때 마다 모니터의 프레임만큼 점점 더 빨라지는 현상이 있었고 다른 창으로 갔을 때 애니메이션 재귀함수가 끝나지 않아 그렇다는것을 확인 후 다른 창에 접근했을 때 발생하는 탈출 조건을 추가했습니다.
 ## 💻 설명 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - requestAnimationFrame()을 사용한 재귀 loop에서 탈출 조건이 따로 없어 창 이동시에도 유지되었고 이 함수를 취소하는 방법은 같은 재귀 안에서 cancelAnimationFrame()을 호출하는 것이었습니다.
  - requestAnimationFrame()은 한 프레임마다 증가하는 정수값을 반환하는데 해당 loop의 정수값을 cancelAnimationFrame()의 인자로 넣어줘야한다고 되어있었고 spa 구조상 각 페이지는 getHtml()과 handleRoute()를 통해 동작하기때문에 그 안에서 flag를 수정할 수 있도록 AnimateGame 객체를 통해 객체의 변수를 다루는 방식을 사용하도록 하였습니다.
  - 추후 online pong에서도 requestAnimationFrame()의 반복 호출이 프레임 증가를 이룰 수 있는 영역이라서 재사용 가능하도록 local pong에서만 가능하지 않게 만들었습니다.
