### PR TITLE
:bug: fix: local pong game의 key down, up event listener가 계속 살아있는 오류 수정

### DIFF
--- a/frontend/src/components/Local.js
+++ b/frontend/src/components/Local.js
@@ -1,5 +1,5 @@
 import AbstractComponent from "./AbstractComponent.js";
-import init from "../games/local_pong.js"
+import {init} from "../games/local_pong.js"
 
 import animateGame from "../utils/animateGameModule.js";
 

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -1,4 +1,5 @@
 import AbstractComponent from "./AbstractComponent.js";
+import {containerEventKeyUp, containerEventKeyDown} from "../games/local_pong.js"
 
 export default class extends AbstractComponent {
 	constructor() {
@@ -14,5 +15,10 @@ export default class extends AbstractComponent {
 		<button class="btn btn-outline-primary" data-href="/local">LOCAL</button>
 		<button class="btn btn-outline-primary" data-href="/lobby">ONLINE</button>
 		`;
+	}
+
+	handleRoute() {
+		window.document.removeEventListener('keydown', containerEventKeyDown);
+		window.document.removeEventListener('keyup', containerEventKeyUp);
 	}
 }

--- a/frontend/src/games/local_pong.js
+++ b/frontend/src/games/local_pong.js
@@ -460,4 +460,4 @@ function simulation_paddle()
     paddle2.position.x += paddle2_spead;
 }
 
-export default init
+export { init, containerEventKeyUp, containerEventKeyDown }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - addEventListener도 removeEventListener로 지워주는 작업이 필요해서 local로 들어가는 버튼이 존재하는 상위 페이지인 main에 제거 로직을 추가했습니다.
 ## 💻 설명 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - getHtml의 내용물에 설정하는 여러 이벤트와 달리 key event는 window의 document에 걸어줘야 합니다.
  - 그 결과 페이지가 바뀌어도 계속해서 이벤트가 살아있었고 animate 관련 처리를 끝낸 후 online pong에 대해 고민하다가 떠올라서 확인해보니 local.js에서 설정된 이벤트가 계속 유지되는 부분을 발견했습니다.
  - 먼저 라우터에서 이벤트를 삭제하는 방식으로 했으나 한류님께서 다른 방식에 대해 말씀해주셔서 local에서 라우터에서 다루는 뒤로가기 이벤트나 버튼을 통한 나가기 이벤트를 통해 접근하게되는 상위 페이지인 main에서 이벤트를 제거하도록 했습니다.
  - 임의로 특정 페이지에 접근하는 경우 새로고침이 발생하여 이벤트 설정이 취소되는 부분까지 확인해두었습니다.
  - online pong에서는 처음부터 설계에 포함하도록 할 예정입니다.
