### PR TITLE
🐛 🐛 🐛 🐛 키다운시 연속 이벤트 발생으로 수많은 send가 보내지는 현상 제거

### DIFF
--- a/frontend/src/games/onlinePongBasic.js
+++ b/frontend/src/games/onlinePongBasic.js
@@ -8,6 +8,9 @@ num = null,
 ARROW_UP = 38,
 ARROW_DOWN = 40,
 
+isArrowUpKeyDown = false,
+isArrowDownKeyDown = false,
+
 WIDTH = 800,
 HEIGHT = 600,
 
@@ -348,8 +351,9 @@ function setEvent()
 
 function onlineContainerEventKeyDown(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === false && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = true;
     // send key down arrow up
     const dataToSend = {
       "action": "key_press",
@@ -363,8 +367,9 @@ function onlineContainerEventKeyDown(e)
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === false && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = true;
     // send key down arrow down
     const dataToSend = {
       "action": "key_press",
@@ -384,8 +389,9 @@ function onlineContainerEventKeyDown(e)
 
 function onlineContainerEventKeyUp(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === true && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = false;
     // send key up arrow up
     const dataToSend = {
       "action": "key_press",
@@ -399,8 +405,9 @@ function onlineContainerEventKeyUp(e)
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === true && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = false;
     // send key up arrow down
     const dataToSend = {
       "action": "key_press",

--- a/frontend/src/games/onlinePongMultiple.js
+++ b/frontend/src/games/onlinePongMultiple.js
@@ -8,6 +8,9 @@ num = null,
 ARROW_UP = 38,
 ARROW_DOWN = 40,
 
+isArrowUpKeyDown = false,
+isArrowDownKeyDown = false,
+
 WIDTH = 800,
 HEIGHT = 600,
 
@@ -430,8 +433,9 @@ function setEvent()
 
 function onlineContainerEventKeyDown(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === false && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = true;
     // send key down arrow up
     const dataToSend = {
       "action": "key_press",
@@ -440,13 +444,16 @@ function onlineContainerEventKeyDown(e)
       "obj": {
         "paddle1_loc": paddle1.position.x,
         "paddle2_loc": paddle2.position.x,
+        "paddle3_loc": paddle3.position.x,
+        "paddle4_loc": paddle4.position.x,
       },
     }
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === false && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = true;
     // send key down arrow down
     const dataToSend = {
       "action": "key_press",
@@ -455,6 +462,8 @@ function onlineContainerEventKeyDown(e)
       "obj": {
         "paddle1_loc": paddle1.position.x,
         "paddle2_loc": paddle2.position.x,
+        "paddle3_loc": paddle3.position.x,
+        "paddle4_loc": paddle4.position.x,
       },
     }
     window.websocket.send(JSON.stringify(dataToSend));
@@ -466,8 +475,9 @@ function onlineContainerEventKeyDown(e)
 
 function onlineContainerEventKeyUp(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === true && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = false;
     // send key up arrow up
     const dataToSend = {
       "action": "key_press",
@@ -476,13 +486,16 @@ function onlineContainerEventKeyUp(e)
       "obj": {
         "paddle1_loc": paddle1.position.x,
         "paddle2_loc": paddle2.position.x,
+        "paddle3_loc": paddle3.position.x,
+        "paddle4_loc": paddle4.position.x,
       },
     }
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === true && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = false;
     // send key up arrow down
     const dataToSend = {
       "action": "key_press",
@@ -491,6 +504,8 @@ function onlineContainerEventKeyUp(e)
       "obj": {
         "paddle1_loc": paddle1.position.x,
         "paddle2_loc": paddle2.position.x,
+        "paddle3_loc": paddle3.position.x,
+        "paddle4_loc": paddle4.position.x,
       },
     }
     window.websocket.send(JSON.stringify(dataToSend));
@@ -521,6 +536,8 @@ function loop()
         "ball_vel": ball.$velocity,
         "paddle1_loc": paddle1.position.x,
         "paddle2_loc": paddle2.position.x,
+        "paddle3_loc": paddle3.position.x,
+        "paddle4_loc": paddle4.position.x,
       }
     }
     window.websocket.send(JSON.stringify(dataToSend));

--- a/frontend/src/games/onlinePongTournament.js
+++ b/frontend/src/games/onlinePongTournament.js
@@ -8,6 +8,9 @@ num = null,
 ARROW_UP = 38,
 ARROW_DOWN = 40,
 
+isArrowUpKeyDown = false,
+isArrowDownKeyDown = false,
+
 WIDTH = 800,
 HEIGHT = 600,
 
@@ -88,6 +91,9 @@ player1_num,
 player2_num,
 round1Winner,
 round1Winner_num,
+round2Winner,
+round2Winner_num,
+
 player_number = null,
 
 scoreBoard,
@@ -290,10 +296,12 @@ function setEvent()
       else if (round === 2)
       {
         round = 3;
-        player2 = win_player;
-        player2_num = win_player_number;
+        round2Winner = win_player;
+        round2Winner_num = win_player_number;
         player1 = round1Winner;
         player1_num = round1Winner_num;
+        player2 = round2Winner;
+        player2_num = round2Winner_num;
         // 만약 필요하다면 roune 2 결과 전송
       }
       else if (round === 3)
@@ -418,8 +426,9 @@ function setEvent()
 
 function onlineContainerEventKeyDown(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === false && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = true;
     // send key down arrow up
     const dataToSend = {
       "action": "key_press",
@@ -433,8 +442,9 @@ function onlineContainerEventKeyDown(e)
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === false && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = true;
     // send key down arrow down
     const dataToSend = {
       "action": "key_press",
@@ -454,8 +464,9 @@ function onlineContainerEventKeyDown(e)
 
 function onlineContainerEventKeyUp(e)
 {
-  if (e.keyCode === ARROW_UP)
+  if (isArrowUpKeyDown === true && e.keyCode === ARROW_UP)
   {
+    isArrowUpKeyDown = false;
     // send key up arrow up
     const dataToSend = {
       "action": "key_press",
@@ -469,8 +480,9 @@ function onlineContainerEventKeyUp(e)
     window.websocket.send(JSON.stringify(dataToSend));
     e.preventDefault();
   }
-  else if (e.keyCode === ARROW_DOWN)
+  else if (isArrowDownKeyDown === true && e.keyCode === ARROW_DOWN)
   {
+    isArrowDownKeyDown = false;
     // send key up arrow down
     const dataToSend = {
       "action": "key_press",


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - keydown이 단일 이벤트가 아니라 눌려있는 상태가 지속된다면 지속적으로 이벤트가 발생하여 send를 보내고 그 부하로 인해 paddle이 비정상적으로 느려지는 현상 수정
 ## 💻 설명 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - keydown, keyup에서 각각 한번씩만 send하도록 flag를 사용해 수정했습니다.
  - 같은 파일이라 한번에 올라갔는데 2vs2에서 p3, p4가 동기화할 때 써야하는 "obj"를 통해 주고받는 loc이 없어서 추가한 부분이 있습니다.
