### PR TITLE
🐛 fix: 토너먼트 라운드종료 핸들링 수정

### DIFF
--- a/frontend/src/games/onlinePongTournament.js
+++ b/frontend/src/games/onlinePongTournament.js
@@ -280,7 +280,7 @@ function setEvent()
 
   window.websocket.onmessage = function (event) {
     const data = JSON.parse(event.data);
-    
+
     if (data["type"] === "init")
       player_number = data["player_number"];
 
@@ -564,25 +564,25 @@ function simulation_ball()
     if(ball.$velocity == null) {
       startOneGame();
     }
-    
+
     updateBallPosition();
-    
+
     if(isSideCollision()) {
-      ball.$velocity.x *= -1; 
+      ball.$velocity.x *= -1;
     }
-    
+
     if(isPaddle1Collision()) {
       hitBallBack(paddle1);
     }
-    
+
     if(isPaddle2Collision()) {
       hitBallBack(paddle2);
     }
-    
+
     if(isPastPaddle1()) {
       scoreBy('player2');
     }
-    
+
     if(isPastPaddle2()) {
       scoreBy('player1');
     }
@@ -636,7 +636,7 @@ function isBallAlignedWithPaddle(paddle)
 
 function hitBallBack(paddle)
 {
-  ball.$velocity.x = (ball.position.x - paddle.position.x) / 5; 
+  ball.$velocity.x = (ball.position.x - paddle.position.x) / 5;
   ball.$velocity.z *= -1;
 }
 
@@ -679,14 +679,14 @@ function updateScoreBoard(playerName)
 
     if (checkTournamentEnd()) {
       const dataToSend = {
-        "action": "tournament_end",
+        "action": "win",
         "tournamentResults": tournamentResults,
       };
       window.websocket.send(JSON.stringify(dataToSend));
     }
 
     const dataToSend = {
-      "action": "win",
+      "action": "round_end",
       "msg": {
         "winner": winner,
         "winner_number": winner_number,

--- a/server/websocket/consumers.py
+++ b/server/websocket/consumers.py
@@ -139,6 +139,23 @@ class RoomConsumer(AsyncWebsocketConsumer):
         elif action == "sync":
             await self.handle_sync(text_data_json["obj"])
 
+        elif action == "round_end":
+            await self.handle_round_end()
+
+    async def handle_round_end(self, msg):
+        await self.channel_layer.group_send(
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "round_end",
+                    "msg": msg,
+                },
+            )
+        )
+
+    async def handle_round_end(self, obj):
+        await self.send(text_data=json.dumps(obj))
+
     async def handle_sync(self, obj):
         await self.channel_layer.group_send(
             self.room_group_name,


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 라운드 종료시 win 대신 round_end, 3라운드 끝나고 토너먼트 끝날시에만 win을 보냅니다
 ## 💻 설명 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -
